### PR TITLE
[#5] Add githooks to enforce branch and commit naming style

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -u
+
+COMMIT_MESSAGE=$(<$1)
+
+VALID_COMMIT_REGEX="^\[#[0-9]+\] "
+
+if [[ ! $COMMIT_MESSAGE =~ $VALID_COMMIT_REGEX ]]; then
+    echo -e "Your commit message doesn't match the accepted format: '[#<Issue Number>] <Description of commit>'"
+    exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -u
+
+BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
+
+VALID_BRANCH_REGEX="^(feature|fix)\/#[0-9]+-[a-zA-Z0-9-]+$"
+
+if [[ ! $BRANCH_NAME =~ $VALID_BRANCH_REGEX ]]
+then
+    echo -e "Your branch name doesn't match the accepted format: '(feature|fix)/#<Issue Number>-description-of-branch'"
+    exit 1
+fi
+
+exit 0

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -u
+
+ISSUE_TAG=$(git rev-parse --abbrev-ref HEAD 2> /dev/null | grep -oE "#[0-9]+")
+
+[[ ! -z "$ISSUE_TAG" ]] && echo "[$ISSUE_TAG] $(cat $1)" > $1
+
+exit 0

--- a/README.adoc
+++ b/README.adoc
@@ -4,14 +4,30 @@ An ETL library for PHP.
 
 == Getting Started
 
+==== Project Dependencies
+
 You will need to install the project dependencies by running the following command.
 
 [source,sh]
 docker-compose run app composer install
 
-== Running Tests
+==== Running Tests
 
 The tests can be run using the following command.
 
 [source,sh]
 docker-compose run app ./vendor/bin/phpunit
+
+==== Git Hooks
+
+This project uses git hooks to enforce a consistent branch and commit naming convention. To enable these hooks during local development you will need to run the following command.
+
+[source,sh]
+git config core.hooksPath ./.githooks
+
+Branch names should obey the following regex.
+
+[source,sh]
+^(feature|fix)\/#[0-9]+-[a-zA-Z0-9-]+$
+
+Commits will then automatically be prepended with the issue number specified after the `#` in the branch name.


### PR DESCRIPTION
Add git hooks to ensure consistent branch and commit naming style